### PR TITLE
docker imageのデフォルトタグの変更

### DIFF
--- a/docker/Dockerfile.apache_rosbridge
+++ b/docker/Dockerfile.apache_rosbridge
@@ -1,5 +1,5 @@
 ##
-## docker build . -f Dockerfile.apache_rosbridge apache_rosbridge:noetic
+## docker build . -f Dockerfile.apache_rosbridge apache_rosbridge:24.04_one
 ##
 ARG BASE_IMAGE=ros:noetic-ros-base
 FROM ${BASE_IMAGE}

--- a/docker/Dockerfile.apache_rosbridge
+++ b/docker/Dockerfile.apache_rosbridge
@@ -1,5 +1,5 @@
 ##
-## docker build . -f Dockerfile.apache_rosbridge apache_rosbridge:24.04_one
+## docker build . -f Dockerfile.apache_rosbridge -t apache_rosbridge:24.04_one --build-arg BASE_IMAGE=ros:one-ros-base
 ##
 ARG BASE_IMAGE=ros:noetic-ros-base
 FROM ${BASE_IMAGE}

--- a/docker/README.md
+++ b/docker/README.md
@@ -135,7 +135,7 @@ sed -i -e 's@\$\$HOSTNAME\$\$@simserver.irsl.eiiris.tut.ac.jp@g' sites-available
 
 ### dockerのビルド
 ``` bash
-docker build . -f Dockerfile.apache_rosbridge apache_rosbridge:noetic
+./build.sh
 ```
 
 ### 立ち上げコマンド

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ abs_dir=$(dirname "$(readlink -f "$0")")
 _COMMON_NAME="eiiris.tut.ac.jp"
 
 _REPO="repo.irsl.eiiris.tut.ac.jp/"
-_TAG="noetic"
+_TAG="24.04_one"
 _KEYS=""
 
 while [[ $# -gt 0 ]]; do
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --common-name COMMON_NAME   Set the common name for SSL certificate generation (default: eiiris.tut.ac.jp)."
             echo "  --repo REPO                 Specify the Docker repository (default: repo.irsl.eiiris.tut.ac.jp/)."
-            echo "  --tag TAG                   Specify the Docker image tag (default: noetic)."
+            echo "  --tag TAG                   Specify the Docker image tag (default: 24.04_one)."
             echo "  --just-keys                 Only generate SSL keys and exit."
             exit 0
             ;;
@@ -61,7 +61,7 @@ fi
 if   [ "${_TAG}" == "noetic" ]; then
 (cd ${abs_dir}; \
 docker build . --pull -f Dockerfile.apache_rosbridge --build-arg BASE_IMAGE=ros:noetic-ros-base -t ${_REPO}apache_rosbridge:noetic ; )
-elif [ "${_TAG}" == "one"    ]; then
+elif [ "${_TAG}" == "24.04_one"    ]; then
 (cd ${abs_dir}; \
-docker build . --pull -f Dockerfile.apache_rosbridge --build-arg BASE_IMAGE=${_REPO}irsl_base:opengl_24.04_one -t ${_REPO}apache_rosbridge:one ; )
+docker build . --pull -f Dockerfile.apache_rosbridge --build-arg BASE_IMAGE=${_REPO}irsl_base:opengl_24.04_one -t ${_REPO}apache_rosbridge:24.04_one ; )
 fi

--- a/docker/www-compose-linux-ssl.yaml
+++ b/docker/www-compose-linux-ssl.yaml
@@ -7,12 +7,12 @@
 # ROS_MASTER_URI ## pass to rosbridge
 # ROS_HOSTNAME ## pass to rosbridge
 # REPO (default: repo.irsl.eiiris.tut.ac.jp/)
-# SUFFIX (default: noetic)
+# SUFFIX (default: 24.04_one)
 # ROOT_DIR (default: $PWD)
 version: "3.0"
 services:
   webserver:
-    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-noetic}
+    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-24.04_one}
     # ipc: host
     security_opt:
       - seccomp:unconfined
@@ -27,7 +27,7 @@ services:
       - "${ROOT_DIR:-$PWD}/userdir:/runshell"
       - "${ROOT_DIR:-$PWD}/../html:/var/www/html"
   rosbridge:
-    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-noetic}
+    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-24.04_one}
     security_opt:
       - seccomp:unconfined
     ports:

--- a/docker/www-compose-linux.yaml
+++ b/docker/www-compose-linux.yaml
@@ -7,12 +7,12 @@
 # ROS_MASTER_URI ## pass to rosbridge
 # ROS_HOSTNAME ## pass to rosbridge
 # REPO (default: repo.irsl.eiiris.tut.ac.jp/)
-# SUFFIX (default: noetic)
+# SUFFIX (default: 24.04_one)
 # ROOT_DIR (default: $PWD)
 version: "3.0"
 services:
   webserver:
-    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-noetic}
+    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-24.04_one}
     # ipc: host
     security_opt:
       - seccomp:unconfined
@@ -27,7 +27,7 @@ services:
       - "${ROOT_DIR:-$PWD}/userdir:/runshell"
       - "${ROOT_DIR:-$PWD}/../html:/var/www/html"
   rosbridge:
-    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-noetic}
+    image: ${REPO:-repo.irsl.eiiris.tut.ac.jp/}apache_rosbridge:${SUFFIX:-24.04_one}
     security_opt:
       - seccomp:unconfined
     ports:

--- a/docker/www-compose-win-ssl.yaml
+++ b/docker/www-compose-win-ssl.yaml
@@ -7,7 +7,7 @@
 version: "3.0"
 services:
   webserver:
-    image: apache_rosbridge_win:noetic
+    image: apache_rosbridge_win:24.04_one
     # ipc: host
     security_opt:
       - seccomp:unconfined
@@ -16,7 +16,7 @@ services:
       - "443:443"
     command: [ "/runshell/run_apache.sh", "${WEB_HOSTNAME:-0.0.0.0}" ]
   rosbridge:
-    image: apache_rosbridge_win:noetic
+    image: apache_rosbridge_win:24.04_one
     security_opt:
       - seccomp:unconfined
     ports:

--- a/docker/www-compose-win.yaml
+++ b/docker/www-compose-win.yaml
@@ -7,7 +7,7 @@
 version: "3.0"
 services:
   webserver:
-    image: apache_rosbridge_win:noetic
+    image: apache_rosbridge_win:24.04_one
     # ipc: host
     security_opt:
       - seccomp:unconfined
@@ -16,7 +16,7 @@ services:
       - "443:443"
     command: [ "/runshell/run_apache.sh", "${WEB_HOSTNAME:-0.0.0.0}" ]
   rosbridge:
-    image: apache_rosbridge_win:noetic
+    image: apache_rosbridge_win:24.04_one
     security_opt:
       - seccomp:unconfined
     ports:


### PR DESCRIPTION
irsl_docker_irsl_systemのデフォルトに合わせるように変更
- `noetic`から`24.04_one`へ変更
- README.mdのbuild部分の記載をコマンドではなくシェルに変更